### PR TITLE
Update ringcentral-sdk.gemspec

### DIFF
--- a/ringcentral-sdk.gemspec
+++ b/ringcentral-sdk.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['spec/**/*.rb']
 
   gem.add_dependency('addressable', '~> 2.8', '>= 2.8.4')
-  gem.add_dependency('concurrent-ruby', '~> 1.2', '>= 1.2.2')
+  gem.add_dependency('concurrent-ruby', '~> 1.1.5')
   gem.add_dependency('pubnub', '~> 5.2', '>= 5.2.2')
   gem.add_dependency('faraday', '~> 2.7', '>= 2.7.4')
   gem.add_dependency('faraday-multipart', '~> 1.0', '>= 1.0.4')


### PR DESCRIPTION
[Pubnub has set the concurrent-ruby](https://github.com/pubnub/ruby/blob/master/pubnub.gemspec) version at `spec.add_dependency 'concurrent-ruby', '~> 1.1.5'` so there is a conflict and I'm unable to install the gem.